### PR TITLE
Add scheme support

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -27,6 +27,8 @@ monitor:
     # Server connection details
     # Host name
     server: openwrt.lan
+    # Scheme (mqtt or mqtts)
+    scheme: mqtt
     # Port number (default: 1883)
     port: 1883
     # User and password if required

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ type Config struct {
 	Monitor struct {
 		MQTT struct {
 			Server          string
+			Scheme		string
 			Port            int
 			User            string
 			Password        string
@@ -470,7 +471,7 @@ func loadConfig() {
 			debug("Disconnected from MQTT (monitoring)")
 		}
 		opts := mqtt.NewClientOptions()
-		opts.AddBroker(fmt.Sprintf("%s://%s:%d", "tcp", getConfig().Monitor.MQTT.Server, getConfig().Monitor.MQTT.Port))
+		opts.AddBroker(fmt.Sprintf("%s://%s:%d", "tcp", getConfig().Monitor.MQTT.Scheme, getConfig().Monitor.MQTT.Server, getConfig().Monitor.MQTT.Port))
 		opts.SetUsername(getConfig().Monitor.MQTT.User)
 		opts.SetPassword(getConfig().Monitor.MQTT.Password)
 		opts.OnConnect = func(c mqtt.Client) {


### PR DESCRIPTION
As per issue #11 I had a bit more of a dig around and was able to add support for specifying the scheme (`mqtt` or `mqtts`).  

I've built it locally and I'm running it fine in my Home Assistant setup. It's simple enough (so doesn't check if the value is `mqtt` or `mqtts`), but does the job for me great. 

Hopefully if you want to add support for this you can use this PR as a starting point (not that it was in anyway complicated to add support for!). I'll continue to use my branch locally, but would be nice if it could be merged for anybody else that may come across the issue I had! 

Thanks :+1: 

